### PR TITLE
Remove issue comment handling from cross-agent collaboration workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,13 @@ jobs:
           node-version: 18
           cache: 'npm'
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v3
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+
       - name: Install dependencies
         run: npm ci
 
@@ -31,6 +38,7 @@ jobs:
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
 
       - name: Run E2E tests (Playwright)
         run: npm run test:e2e

--- a/.github/workflows/cross-agent-collaboration.yml
+++ b/.github/workflows/cross-agent-collaboration.yml
@@ -2,11 +2,9 @@ name: Cross-Agent Collaboration
 
 on:
   pull_request:
-    types: [ opened, reopened, synchronize, ready_for_review ]
+    types: [opened, reopened, synchronize, ready_for_review]
   pull_request_review:
-    types: [ submitted ]
-  issue_comment:
-    types: [ created ]
+    types: [submitted]
 
 permissions:
   contents: read
@@ -23,14 +21,8 @@ jobs:
       - name: Determine PR & Agent Type
         id: pr_info
         run: |
-          if [ "${{ github.event_name }}" = "issue_comment" ]; then
-            PR_NUM=$(echo "${{ github.event.issue.html_url }}" | grep -o '[0-9]\+$')
-            echo "pr_number=$PR_NUM" >> $GITHUB_OUTPUT
-            HEAD_REF=$(gh pr view $PR_NUM --json headRefName -q .headRefName)
-          else
-            echo "pr_number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
-            HEAD_REF="${{ github.event.pull_request.head.ref }}"
-          fi
+          echo "pr_number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          HEAD_REF="${{ github.event.pull_request.head.ref }}"
 
           if [[ "$HEAD_REF" == feature/alpha/* ]]; then
             echo "agent=alpha" >> $GITHUB_OUTPUT
@@ -49,7 +41,7 @@ jobs:
           cat <<EOF > report.md
           # Cross-Agent Collaboration Report
 
-          **PR #**: ${{ steps.pr_info.outputs.pr_number }}  
+          **PR #**: ${{ steps.pr_info.outputs.pr_number }}
           **Agent**: ${{ steps.pr_info.outputs.agent }}
 
           EOF
@@ -58,21 +50,18 @@ jobs:
             echo "Waiting for review by the ${{ steps.pr_info.outputs.other_agent }} agent." >> report.md
           elif [ "${{ github.event_name }}" = "pull_request_review" ] && [ "${{ github.event.review.state }}" = "approved" ]; then
             echo "✅ Approved by the ${{ steps.pr_info.outputs.other_agent }} agent!" >> report.md
-          elif [ "${{ github.event_name }}" = "issue_comment" ]; then
-            echo "💬 Comment by the ${{ steps.pr_info.outputs.other_agent }} agent detected. Please address feedback." >> report.md
           fi
 
       - name: Post Collaboration Report
         uses: actions/github-script@v7
         if: |
           github.event_name == 'pull_request' ||
-          (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') ||
-          github.event_name == 'issue_comment'
+          (github.event_name == 'pull_request_review' && github.event.review.state == 'approved')
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const report = require('fs').readFileSync('report.md','utf8');
-            const pr = parseInt(process.env.GITHUB_REF.split('/').pop() || '${{ steps.pr_info.outputs.pr_number }}');
+            const pr = parseInt('${{ steps.pr_info.outputs.pr_number }}');
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/project-memory.json
+++ b/project-memory.json
@@ -15,6 +15,10 @@
     "alpha": "feature dev & unit tests",
     "beta": "QA, lint, docs, E2E tests"
   },
+  "workflow": {
+    "pr_creation": "agents can create full PRs with GitHub CLI",
+    "branching": "feature branches should follow feature/alpha/* or feature/beta/* pattern"
+  },
   "must": [
     "compile with no TS errors",
     "run all unit + E2E tests",

--- a/project-memory.json
+++ b/project-memory.json
@@ -17,7 +17,8 @@
   },
   "workflow": {
     "pr_creation": "agents can create full PRs with GitHub CLI",
-    "branching": "feature branches should follow feature/alpha/* or feature/beta/* pattern"
+    "branching": "feature branches should follow feature/alpha/* or feature/beta/* pattern",
+    "ci_checks": "wait 30 seconds after making/updating PRs to check for CI status and comments"
   },
   "must": [
     "compile with no TS errors",

--- a/project-memory.json
+++ b/project-memory.json
@@ -18,7 +18,7 @@
   "workflow": {
     "pr_creation": "agents can create full PRs with GitHub CLI",
     "branching": "feature branches should follow feature/alpha/* or feature/beta/* pattern",
-    "ci_checks": "wait 30 seconds after making/updating PRs to check for CI status and comments"
+    "ci_checks": "wait 30 seconds after making/updating PRs to check for CI status and comments, and continue checking until all checks are finished"
   },
   "must": [
     "compile with no TS errors",


### PR DESCRIPTION
This PR removes the issue comment handling from the cross-agent collaboration workflow to prevent automatic comments from the other agent when comments are added to PRs. The workflow will now only run when a PR is opened/updated or when a review is submitted.