### PR TITLE
Update project-memory.json to explicitly prohibit pushing directly to develop

### DIFF
--- a/project-memory.json
+++ b/project-memory.json
@@ -20,7 +20,8 @@
     "branching": "feature branches should follow feature/alpha/* or feature/beta/* pattern and always branch from develop, never from main",
     "ci_checks": "wait 30 seconds after making/updating PRs to check for CI status and comments, and continue checking until all checks are finished",
     "pr_review": "when working with another agent to review, approve, and merge PRs, sleep the terminal for 30 seconds between checks to see any comments or reviews from the other agent",
-    "release_process": "never push directly to main; only release to main when develop is fully tested and ready for release"
+    "release_process": "never push directly to main; only release to main when develop is fully tested and ready for release",
+    "branch_protection": "never push directly to develop branch; always use feature branches and PRs for all changes"
   },
   "must": [
     "compile with no TS errors",
@@ -35,6 +36,7 @@
     "depend on external visual editors",
     "merge without green CI",
     "push directly to main",
+    "push directly to develop branch",
     "create feature branches from main"
   ]
 }


### PR DESCRIPTION
## Description

This PR updates the project-memory.json file to explicitly state that we should never push directly to the develop branch. All changes should be made in feature branches and merged via PRs.

### Changes

1. Added a new entry in the 'workflow' section:
   - 'branch_protection': 'never push directly to develop branch; always use feature branches and PRs for all changes'

2. Added a new entry in the 'donot' section:
   - 'push directly to develop branch'

These changes reinforce our branching strategy and help prevent accidental direct pushes to the develop branch.