### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,90 @@
+name: Deploy to GitHub Pages
+
+on:
+  # Manual trigger
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to deploy (e.g., v1.0.0)'
+        required: true
+        default: ''
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: develop
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Create release branch
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+          git checkout -b release/${{ github.event.inputs.version }}
+
+      - name: Update Vite config for GitHub Pages
+        run: |
+          # Use sed to add base config to vite.config.ts
+          sed -i '/defineConfig({/a\  base: "\/signal-lost-2\/",\' vite.config.ts
+          git add vite.config.ts
+          git commit -m "chore: configure GitHub Pages base path"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: |
+          npm run test:unit
+          npm run test:e2e:ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Prepare docs directory
+        run: |
+          rm -rf docs
+          mkdir docs
+          cp -r dist/* docs/
+          git add docs
+          git commit -m "chore: build for GitHub Pages"
+
+      - name: Push release branch
+        run: git push origin release/${{ github.event.inputs.version }}
+
+      - name: Create Pull Request to main
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: main
+          head: release/${{ github.event.inputs.version }}
+          title: "Release ${{ github.event.inputs.version }}"
+          body: |
+            This PR deploys version ${{ github.event.inputs.version }} to GitHub Pages.
+            
+            Changes included in this release:
+            - [List major changes here]
+          
+      - name: Deploy to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: docs
+          branch: gh-pages
+          
+      - name: Create Pull Request to develop
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: develop
+          head: release/${{ github.event.inputs.version }}
+          title: "Sync develop with release ${{ github.event.inputs.version }}"
+          body: |
+            This PR syncs the develop branch with the changes made during the release process.

--- a/README.md
+++ b/README.md
@@ -208,3 +208,21 @@ These guides serve as valuable references to prevent over-engineering and help b
 - Add more puzzle types (pressure plates, moving platforms)
 
 See [TODO.md](./TODO.md), [TODO-ALPHA.md](./TODO-ALPHA.md), and [TODO-BETA.md](./TODO-BETA.md) for detailed lists of current issues and next steps.
+
+## 🚀 Deployment
+
+The game is deployed to GitHub Pages using a GitHub Actions workflow. To deploy a new version:
+
+1. Ensure all changes are merged to the `develop` branch and all tests are passing
+2. Run the deployment script with a version number:
+   ```bash
+   ./scripts/deploy.sh v1.0.0
+   ```
+3. The workflow will:
+   - Create a release branch from `develop`
+   - Configure the application for GitHub Pages
+   - Build and test the application
+   - Deploy to GitHub Pages
+   - Create PRs to merge the release branch to both `main` and back to `develop`
+
+Once deployed, the game will be available at: https://capncrockett.github.io/signal-lost-2/

--- a/TODO-BETA.md
+++ b/TODO-BETA.md
@@ -30,6 +30,10 @@
   - ✅ Added direct scene navigation to bypass UI interaction issues
   - ✅ Added better error handling and logging for test failures
   - ✅ Updated TODO-ALPHA.md with issues that need to be fixed
+- [ ] Monitor and maintain GitHub Pages deployment
+  - [ ] Test the deployment workflow
+  - [ ] Ensure the game works correctly on GitHub Pages
+  - [ ] Update documentation if deployment issues are found
 
 ### Low Priority
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -e
+
+# Check if version is provided
+if [ -z "$1" ]; then
+  echo "Error: Version parameter is required"
+  echo "Usage: ./scripts/deploy.sh v1.0.0"
+  exit 1
+fi
+
+VERSION=$1
+
+# Trigger the GitHub Actions workflow
+gh workflow run deploy.yml -f version=$VERSION
+
+echo "✅ Deployment workflow triggered for version $VERSION"
+echo "Check the status at: https://github.com/capncrockett/signal-lost-2/actions"
+echo "Once deployed, your game will be live at: https://capncrockett.github.io/signal-lost-2/"


### PR DESCRIPTION
This PR adds a GitHub Pages deployment workflow and documentation:

- Added a GitHub Actions workflow file (.github/workflows/deploy.yml) that:
  - Creates a release branch from develop
  - Configures the application for GitHub Pages
  - Builds and tests the application
  - Deploys to GitHub Pages
  - Creates PRs to merge the release branch to both main and back to develop

- Added a deployment script (scripts/deploy.sh) to trigger the workflow

- Updated README.md with deployment instructions

- Updated TODO-BETA.md with tasks for monitoring the deployment process

This workflow aligns with our branching strategy where all work branches from develop and only releases to main when develop is fully tested and ready.