### PR TITLE
Fix: Update index.html to use bundled JavaScript file

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
       </div>
     </div>
 
-    <script type="module" src="./src/main.ts"></script>
+    <script type="module" src="./docs/assets/index.cfefdd03.js"></script>
     <script>
       // Debug panel functionality
       document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
This PR fixes the MIME type issues on GitHub Pages by:\n\n1. Updating the index.html file in the root directory to use the bundled JavaScript file instead of the TypeScript file\n2. This ensures that the browser doesn't try to load the TypeScript file directly, which GitHub Pages serves with the wrong MIME type (video/mp2t)\n\nThe issue was that GitHub Pages is configured to serve files from the root directory of the main branch, not from the docs directory, so we need to update the index.html file in the root directory to use the bundled JavaScript file.