### PR TITLE
Set PowerShell as default terminal for Windows

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,10 @@
     "source.fixAll": "explicit"
   },
   "typescript.tsdk": "node_modules/typescript/lib",
-  "typescript.enablePromptUseWorkspaceTsdk": true
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+  "terminal.integrated.defaultProfile.windows": "PowerShell",
+  "terminal.integrated.automationProfile.windows": {
+    "path": "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+    "args": []
+  }
 }


### PR DESCRIPTION
This PR sets PowerShell as the default terminal for Windows in the project's VS Code settings.

Changes:
- Added  setting to use PowerShell
- Added  to use PowerShell for automation tasks

This change improves the development experience by ensuring consistent terminal behavior across the team.