### PR TITLE
Add VS Code workspace file with PowerShell as default terminal

### DIFF
--- a/.vscode/signal-lost-2.code-workspace
+++ b/.vscode/signal-lost-2.code-workspace
@@ -1,0 +1,16 @@
+{
+	"folders": [
+		{
+			"path": ".."
+		}
+	],
+	"settings": {
+		"typescript.tsdk": "node_modules/typescript/lib",
+		"typescript.enablePromptUseWorkspaceTsdk": true,
+		"terminal.integrated.defaultProfile.windows": "PowerShell",
+		"terminal.integrated.automationProfile.windows": {
+			"path": "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+			"args": []
+		}
+	}
+}


### PR DESCRIPTION
This PR adds the VS Code workspace file to the repository with PowerShell configured as the default terminal for Windows users.

Changes:
- Added .vscode/signal-lost-2.code-workspace file
- Configured PowerShell as the default terminal for Windows
- Configured PowerShell for automation tasks on Windows

This change ensures a consistent development environment for Windows users and prevents issues with terminal commands.